### PR TITLE
Fix insecure password salt generation

### DIFF
--- a/Helpers/PasswordHelper.cs
+++ b/Helpers/PasswordHelper.cs
@@ -15,11 +15,13 @@ namespace Web_SIMS.Helpers
             }
         }
 
-        public static string GenerateSalt()
+        public static string GenerateSalt(int size = 16)
         {
-            var random = new Random();
-            var salt = new byte[16];
-            random.NextBytes(salt);
+            var salt = new byte[size];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(salt);
+            }
             return Convert.ToBase64String(salt);
         }
 


### PR DESCRIPTION
## Summary
- use `RandomNumberGenerator` instead of `Random` when creating a password salt

## Testing
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_b_688a10df34b8832298e06a584f120f3d