### PR TITLE
Add admin endpoint routes

### DIFF
--- a/Controllers/CourseController.cs
+++ b/Controllers/CourseController.cs
@@ -8,8 +8,9 @@ using Web_SIMS.ViewModels;
 
 namespace Web_SIMS.Controllers
 {
-    [Authorize(Roles = "Admin,Faculty")]
-    public class CourseController : Controller
+[Authorize(Roles = "Admin,Faculty")]
+[Route("admin/courses")]
+public class CourseController : Controller
     {
         private readonly AppDbContext _context;
         private readonly ILogger<CourseController> _logger;
@@ -20,7 +21,8 @@ namespace Web_SIMS.Controllers
             _logger = logger;
         }
 
-        // GET: Course
+        // GET: /admin/courses
+        [HttpGet("")]
         public async Task<IActionResult> Index(string searchString, string sortOrder, int? pageNumber)
         {
             ViewData["CurrentSort"] = sortOrder;
@@ -58,7 +60,8 @@ namespace Web_SIMS.Controllers
             return View(await PaginatedList<Course>.CreateAsync(courses.AsNoTracking(), pageNumber ?? 1, pageSize));
         }
 
-        // GET: Course/Details/5
+        // GET: /admin/courses/{id}
+        [HttpGet("{id}")]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -81,14 +84,15 @@ namespace Web_SIMS.Controllers
             return View(course);
         }
 
-        // GET: Course/Create
+        // GET: /admin/courses/create
+        [HttpGet("create")]
         public IActionResult Create()
         {
             return View();
         }
 
-        // POST: Course/Create
-        [HttpPost]
+        // POST: /admin/courses
+        [HttpPost("")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("CourseCode,CourseName,Description,Credits,MaxStudents,Semester,AcademicYear,Instructor")] Course course)
         {
@@ -115,7 +119,8 @@ namespace Web_SIMS.Controllers
             return View(course);
         }
 
-        // GET: Course/Edit/5
+        // GET: /admin/courses/edit/{id}
+        [HttpGet("edit/{id}")]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -131,8 +136,9 @@ namespace Web_SIMS.Controllers
             return View(course);
         }
 
-        // POST: Course/Edit/5
-        [HttpPost]
+        // POST: /admin/courses/{id}
+        [HttpPost("{id}")]
+        [HttpPut("{id}")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("CourseId,CourseCode,CourseName,Description,Credits,MaxStudents,Semester,AcademicYear,Instructor,IsActive")] Course course)
         {
@@ -175,7 +181,8 @@ namespace Web_SIMS.Controllers
             return View(course);
         }
 
-        // GET: Course/Delete/5
+        // GET: /admin/courses/delete/{id}
+        [HttpGet("delete/{id}")]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -193,8 +200,9 @@ namespace Web_SIMS.Controllers
             return View(course);
         }
 
-        // POST: Course/Delete/5
-        [HttpPost, ActionName("Delete")]
+        // DELETE: /admin/courses/{id}
+        [HttpPost("delete/{id}")]
+        [HttpDelete("{id}")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {

--- a/Controllers/DashboardController.cs
+++ b/Controllers/DashboardController.cs
@@ -8,8 +8,9 @@ using Web_SIMS.ViewModels;
 
 namespace Web_SIMS.Controllers
 {
-    [Authorize]
-    public class DashboardController : Controller
+[Authorize]
+[Route("admin/dashboard")]
+public class DashboardController : Controller
     {
         private readonly AppDbContext _context;
         private readonly ILogger<DashboardController> _logger;
@@ -20,6 +21,7 @@ namespace Web_SIMS.Controllers
             _logger = logger;
         }
 
+        [HttpGet("")]
         public async Task<IActionResult> Index()
         {
             try

--- a/Controllers/EnrollmentController.cs
+++ b/Controllers/EnrollmentController.cs
@@ -8,8 +8,9 @@ using Web_SIMS.ViewModels;
 
 namespace Web_SIMS.Controllers
 {
-    [Authorize]
-    public class EnrollmentController : Controller
+[Authorize]
+[Route("admin/enrollments")]
+public class EnrollmentController : Controller
     {
         private readonly AppDbContext _context;
         private readonly ILogger<EnrollmentController> _logger;
@@ -20,7 +21,8 @@ namespace Web_SIMS.Controllers
             _logger = logger;
         }
 
-        // GET: Enrollment
+        // GET: /admin/enrollments
+        [HttpGet("")]
         public async Task<IActionResult> Index(string searchString, string statusFilter, int? pageNumber)
         {
             ViewData["CurrentFilter"] = searchString;
@@ -52,7 +54,8 @@ namespace Web_SIMS.Controllers
             return View(await PaginatedList<Enrollment>.CreateAsync(enrollments.AsNoTracking(), pageNumber ?? 1, pageSize));
         }
 
-        // GET: Enrollment/Details/5
+        // GET: /admin/enrollments/{id}
+        [HttpGet("{id}")]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -73,8 +76,9 @@ namespace Web_SIMS.Controllers
             return View(enrollment);
         }
 
-        // GET: Enrollment/Create
+        // GET: /admin/enrollments/create
         [Authorize(Roles = "Admin,Faculty")]
+        [HttpGet("create")]
         public async Task<IActionResult> Create()
         {
             ViewData["StudentId"] = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(_context.Students.Where(s => s.IsActive), "StudentId", "FullName");
@@ -82,8 +86,8 @@ namespace Web_SIMS.Controllers
             return View();
         }
 
-        // POST: Enrollment/Create
-        [HttpPost]
+        // POST: /admin/enrollments
+        [HttpPost("")]
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Admin,Faculty")]
         public async Task<IActionResult> Create([Bind("StudentId,CourseId,Notes")] Enrollment enrollment)
@@ -131,8 +135,9 @@ namespace Web_SIMS.Controllers
             return View(enrollment);
         }
 
-        // GET: Enrollment/Edit/5
+        // GET: /admin/enrollments/edit/{id}
         [Authorize(Roles = "Admin,Faculty")]
+        [HttpGet("edit/{id}")]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -153,8 +158,9 @@ namespace Web_SIMS.Controllers
             return View(enrollment);
         }
 
-        // POST: Enrollment/Edit/5
-        [HttpPost]
+        // POST: /admin/enrollments/{id}
+        [HttpPost("{id}")]
+        [HttpPut("{id}")]
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Admin,Faculty")]
         public async Task<IActionResult> Edit(int id, [Bind("EnrollmentId,StudentId,CourseId,EnrollmentDate,Status,Notes")] Enrollment enrollment)
@@ -190,8 +196,8 @@ namespace Web_SIMS.Controllers
             return View(enrollment);
         }
 
-        // POST: Enrollment/Approve/5
-        [HttpPost]
+        // POST: /admin/enrollments/approve/{id}
+        [HttpPost("approve/{id}")]
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Admin,Faculty")]
         public async Task<IActionResult> Approve(int id)
@@ -224,8 +230,8 @@ namespace Web_SIMS.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        // POST: Enrollment/Reject/5
-        [HttpPost]
+        // POST: /admin/enrollments/reject/{id}
+        [HttpPost("reject/{id}")]
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Admin,Faculty")]
         public async Task<IActionResult> Reject(int id)
@@ -245,8 +251,9 @@ namespace Web_SIMS.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        // GET: Enrollment/Delete/5
+        // GET: /admin/enrollments/delete/{id}
         [Authorize(Roles = "Admin,Faculty")]
+        [HttpGet("delete/{id}")]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -267,8 +274,9 @@ namespace Web_SIMS.Controllers
             return View(enrollment);
         }
 
-        // POST: Enrollment/Delete/5
-        [HttpPost, ActionName("Delete")]
+        // DELETE: /admin/enrollments/{id}
+        [HttpPost("delete/{id}")]
+        [HttpDelete("{id}")]
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Admin,Faculty")]
         public async Task<IActionResult> DeleteConfirmed(int id)

--- a/Controllers/StudentController.cs
+++ b/Controllers/StudentController.cs
@@ -8,8 +8,9 @@ using Web_SIMS.ViewModels;
 
 namespace Web_SIMS.Controllers
 {
-    [Authorize(Roles = "Admin,Faculty")]
-    public class StudentController : Controller
+[Authorize(Roles = "Admin,Faculty")]
+[Route("admin/students")]
+public class StudentController : Controller
     {
         private readonly AppDbContext _context;
         private readonly ILogger<StudentController> _logger;
@@ -20,7 +21,8 @@ namespace Web_SIMS.Controllers
             _logger = logger;
         }
 
-        // GET: Student
+        // GET: /admin/students
+        [HttpGet("")]
         public async Task<IActionResult> Index(string searchString, string sortOrder, int? pageNumber)
         {
             ViewData["CurrentSort"] = sortOrder;
@@ -58,7 +60,8 @@ namespace Web_SIMS.Controllers
             return View(await PaginatedList<Student>.CreateAsync(students.AsNoTracking(), pageNumber ?? 1, pageSize));
         }
 
-        // GET: Student/Details/5
+        // GET: /admin/students/{id}
+        [HttpGet("{id}")]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -81,14 +84,15 @@ namespace Web_SIMS.Controllers
             return View(student);
         }
 
-        // GET: Student/Create
+        // GET: /admin/students/create
+        [HttpGet("create")]
         public IActionResult Create()
         {
             return View();
         }
 
-        // POST: Student/Create
-        [HttpPost]
+        // POST: /admin/students
+        [HttpPost("")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("StudentCode,FullName,Email,PhoneNumber,DateOfBirth,Address,Gender,Major,AcademicYear,Notes")] Student student)
         {
@@ -123,7 +127,8 @@ namespace Web_SIMS.Controllers
             return View(student);
         }
 
-        // GET: Student/Edit/5
+        // GET: /admin/students/edit/{id}
+        [HttpGet("edit/{id}")]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -139,8 +144,9 @@ namespace Web_SIMS.Controllers
             return View(student);
         }
 
-        // POST: Student/Edit/5
-        [HttpPost]
+        // POST: /admin/students/{id}
+        [HttpPost("{id}")]
+        [HttpPut("{id}")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("StudentId,StudentCode,FullName,Email,PhoneNumber,DateOfBirth,Address,Gender,Major,AcademicYear,Notes,IsActive")] Student student)
         {
@@ -190,7 +196,8 @@ namespace Web_SIMS.Controllers
             return View(student);
         }
 
-        // GET: Student/Delete/5
+        // GET: /admin/students/delete/{id}
+        [HttpGet("delete/{id}")]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -208,8 +215,9 @@ namespace Web_SIMS.Controllers
             return View(student);
         }
 
-        // POST: Student/Delete/5
-        [HttpPost, ActionName("Delete")]
+        // DELETE: /admin/students/{id}
+        [HttpPost("delete/{id}")]
+        [HttpDelete("{id}")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -9,8 +9,9 @@ using Web_SIMS.ViewModels;
 
 namespace Web_SIMS.Controllers
 {
-    [Authorize(Roles = "Admin")]
-    public class UserController : Controller
+[Authorize(Roles = "Admin")]
+[Route("admin/users")]
+public class UserController : Controller
     {
         private readonly AppDbContext _context;
         private readonly ILogger<UserController> _logger;
@@ -21,7 +22,8 @@ namespace Web_SIMS.Controllers
             _logger = logger;
         }
 
-        // GET: User
+        // GET: /admin/users
+        [HttpGet("")]
         public async Task<IActionResult> Index(string searchString, string sortOrder, int? pageNumber)
         {
             ViewData["CurrentSort"] = sortOrder;
@@ -59,7 +61,8 @@ namespace Web_SIMS.Controllers
             return View(await PaginatedList<User>.CreateAsync(users.AsNoTracking(), pageNumber ?? 1, pageSize));
         }
 
-        // GET: User/Details/5
+        // GET: /admin/users/{id}
+        [HttpGet("{id}")]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -79,15 +82,16 @@ namespace Web_SIMS.Controllers
             return View(user);
         }
 
-        // GET: User/Create
+        // GET: /admin/users/create
+        [HttpGet("create")]
         public IActionResult Create()
         {
             ViewData["RoleId"] = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(_context.Roles.Where(r => r.IsActive), "RoleId", "RoleName");
             return View();
         }
 
-        // POST: User/Create
-        [HttpPost]
+        // POST: /admin/users
+        [HttpPost("")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("Username,Password,Email,FullName,RoleId")] User user)
         {
@@ -128,7 +132,8 @@ namespace Web_SIMS.Controllers
             return View(user);
         }
 
-        // GET: User/Edit/5
+        // GET: /admin/users/edit/{id}
+        [HttpGet("edit/{id}")]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -145,8 +150,9 @@ namespace Web_SIMS.Controllers
             return View(user);
         }
 
-        // POST: User/Edit/5
-        [HttpPost]
+        // POST: /admin/users/{id}
+        [HttpPost("{id}")]
+        [HttpPut("{id}")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("UserId,Username,Email,FullName,RoleId,IsActive")] User user)
         {
@@ -199,7 +205,8 @@ namespace Web_SIMS.Controllers
             return View(user);
         }
 
-        // GET: User/Delete/5
+        // GET: /admin/users/delete/{id}
+        [HttpGet("delete/{id}")]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -218,8 +225,9 @@ namespace Web_SIMS.Controllers
             return View(user);
         }
 
-        // POST: User/Delete/5
-        [HttpPost, ActionName("Delete")]
+        // DELETE: /admin/users/{id}
+        [HttpPost("delete/{id}")]
+        [HttpDelete("{id}")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {


### PR DESCRIPTION
## Summary
- add admin area route prefixes for StudentController, CourseController, EnrollmentController, UserController and DashboardController
- expose CRUD actions under `/admin/*` paths

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_b_688a20d9c3b88322b185632f5e0cee2e